### PR TITLE
新增执行多行命令模块（支持 /pdrwait <f> 指令）

### DIFF
--- a/Helpers/MultiLineCommandHelper.cs
+++ b/Helpers/MultiLineCommandHelper.cs
@@ -25,7 +25,7 @@ public static class MultiLineCommandHelper
                 }
 
                 ChatHelper.SendMessage(command);
-                await Task.Delay(200);  //每条命令之间有足够间隔，以确保顺序执行
+                await Task.Delay(50);  //每条命令之间有足够间隔，以确保顺序执行
             }
             catch (Exception ex)
             {

--- a/Helpers/MultiLineCommandHelper.cs
+++ b/Helpers/MultiLineCommandHelper.cs
@@ -17,7 +17,7 @@ public static class MultiLineCommandHelper
 
             try
             {
-                if (command.Trim().StartsWith("/pdrwait ") &&
+                if (command.Trim().StartsWith("/wait ") &&
                     float.TryParse(command.Trim().Split(' ')[1], out var waitTime))
                 {
                     await Task.Delay((int) waitTime * 1000);

--- a/Helpers/MultiLineCommandHelper.cs
+++ b/Helpers/MultiLineCommandHelper.cs
@@ -1,3 +1,5 @@
+using Dalamud.Utility;
+
 namespace OmenTools.Helpers;
 
 public static class MultiLineCommandHelper
@@ -12,7 +14,7 @@ public static class MultiLineCommandHelper
 
         var commands = message.Split('\n')
                               .Select(c => c.Trim())
-                              .Where(c => !string.IsNullOrWhiteSpace(c));
+                              .Where(c => !c.IsNullOrWhitespace());
 
         foreach (var command in commands)
         {

--- a/Helpers/MultiLineCommandHelper.cs
+++ b/Helpers/MultiLineCommandHelper.cs
@@ -1,0 +1,36 @@
+namespace OmenTools.Helpers;
+
+public static class MultiLineCommandHelper
+{
+    public static async Task SendMultiLineCommandAsync(string message)
+    {
+        if (string.IsNullOrEmpty(message))
+        {
+            DService.Log.Error("待发送消息为空");
+            return;
+        }
+
+        foreach (var command in message.Split('\n'))
+        {
+            if (string.IsNullOrWhiteSpace(command))
+                continue;
+
+            try
+            {
+                if (command.Trim().StartsWith("/pdrwait ") &&
+                    float.TryParse(command.Trim().Split(' ')[1], out var waitTime))
+                {
+                    await Task.Delay((int) waitTime * 1000);
+                    continue;
+                }
+
+                ChatHelper.SendMessage(command);
+                await Task.Delay(200);  //每条命令之间有足够间隔，以确保顺序执行
+            }
+            catch (Exception ex)
+            {
+                DService.Log.Error($"执行命令时出错: {command}\n错误: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
添加了一个新的辅助模块 MultiLineCommandHelper，用于依次发送多行聊天命令，支持在命令之间插入 /pdrwait <f> 语句，实现定时等待后再继续执行下一条指令。

- 支持用户输入的多行命令文本，通过换行分隔
- 可在加入 /pdrwait 0.5 等命令，在命令执行中插入延迟
- 每条命令之间添加了间隔（50ms）确保顺序执行

具体需求场景见用户反馈：
https://discord.com/channels/1258981591124938762/1313692277897691256/1384383031305048194